### PR TITLE
support for wait-for-device

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ Currently following adb commands are **supported**:
 * adb get-state
 * adb sync
 * adb version
+* adb bugreport
 
 Currently following adb commands are **not supported**:
 
 * adb forward
 * adb wait-for-device
 * adb logcat
-* adb bugreport
 * adb jdwp
 * adb help
 * adb -d
@@ -54,6 +54,7 @@ adb_android.push('/tmp/file.txt', '/data/media/0')
 adb_android.pull('/data/media/0/file.txt', '/tmp/')
 adb_android.shell('ls')
 adb_android.devices()
+adb_android.bugreport("report.log")
 adb_android.install('/usr/local/app.apk')
 adb_android.uninstall('com.example.android.valid')
 adb_android.getserialno()

--- a/tests/test_adb_android.py
+++ b/tests/test_adb_android.py
@@ -272,7 +272,7 @@ class TestBugreport(unittest.TestCase):
     @unittest.skipUnless(is_device_available(), 'device not available')
     def test_bugreport(self):
         result = adb.bugreport()
-        result[0].should.match(POSITIVE_EXP_RESULT)
+        result[0].should.be(POSITIVE_EXP_RESULT)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added the following:
- support for wait-for-device
- function _execute_with_timer(), where the function exits after the timer specified by the user. This is needed by wait-for-device as this command might wait infinitely for the device.
